### PR TITLE
Enable support for .ts files via node and esbuild type stripping

### DIFF
--- a/.github/workflows/neocities.yml
+++ b/.github/workflows/neocities.yml
@@ -6,7 +6,6 @@ on:
       - master
 
 env:
-  node-version: lts/*
   FORCE_COLOR: 1
 
 concurrency: # prevent concurrent deploys doing starnge things
@@ -23,7 +22,7 @@ jobs:
     - name: Use Node.js
       uses: actions/setup-node@v4
       with:
-        node-version: ${{env.node-version}}
+        node-version-file: package.json
         check-latest: true
     - run: npm i
     - run: npm run build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,8 +8,7 @@ on:
         required: true
 
 env:
-  node_version: lts/*
-  FORCE_COLOR: 2
+  FORCE_COLOR: 1
 
 jobs:
   version_and_release:
@@ -19,10 +18,10 @@ jobs:
       with:
         # fetch full history so things like auto-changelog work properly
         fetch-depth: 0
-    - name: Use Node.js ${{ env.node_version }}
+    - name: Use Node.js
       uses: actions/setup-node@v4
       with:
-        node-version: ${{ env.node_version }}
+        node-version-file: package.json
         check-latest: true
         # setting a registry enables the NODE_AUTH_TOKEN env variable where we can set an npm token.  REQUIRED
         registry-url: 'https://registry.npmjs.org'
@@ -37,4 +36,3 @@ jobs:
         newversion: ${{ github.event.inputs.newversion }}
         github_token: ${{ secrets.GITHUB_TOKEN }} # built in actions token.  Passed tp gh-release if in use.
         npm_token: ${{ secrets.NPM_TOKEN }} # user set secret token generated at npm
-

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,4 +1,3 @@
----
 name: tests
 
 on: [pull_request, push]
@@ -13,7 +12,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        node-version: [lts/*]
+        node-version: [lts/*, '23']
 
     steps:
       - uses: actions/checkout@v4
@@ -23,12 +22,30 @@ jobs:
           node-version: ${{ matrix.node-version }}
           check-latest: true
       - run: npm i
-      - run: npm test
+      - name: Run tests
+        run: |
+          node_major=$(node -p "process.versions.node.split('.')[0]")
+          if [ "$node_major" -lt 23 ]; then
+            NODE_OPTIONS="--experimental-strip-types" npm test
+          else
+            npm test
+          fi
       - name: Coveralls
         uses: coverallsapp/github-action@v2
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           files: .tap/report/lcov.info
+          parallel: true
+
+  coverage:
+    needs: test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Close parallel build
+        uses: coverallsapp/github-action@v2
+        with:
+          parallel-finished: true
+
 
   automerge:
     needs: test

--- a/examples/type-stripping/package.json
+++ b/examples/type-stripping/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "@top-bun/preact-example",
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "start": "npm run watch",
+    "build": "npm run clean && top-bun",
+    "clean": "rm -rf public && mkdir -p public",
+    "watch": "npm run clean && tb --watch"
+  },
+  "author": "Bret Comnes <bcomnes@gmail.com> (https://bret.io/)",
+  "license": "MIT",
+  "dependencies": {
+    "@preact/signals": "^2.0.0",
+    "highlight.js": "^11.9.0",
+    "htm": "^3.1.1",
+    "mine.css": "^9.0.1",
+    "preact": "^10.24.0",
+    "preact-render-to-string": "^6.5.11",
+    "top-bun": "../../."
+  },
+  "devDependencies": {
+    "@voxpelli/tsconfig": "^15.0.0",
+    "npm-run-all2": "^6.0.0",
+    "typescript": "~5.8.2"
+  }
+}

--- a/examples/type-stripping/src/README.md
+++ b/examples/type-stripping/src/README.md
@@ -1,0 +1,5 @@
+# Preact example
+
+This is a preact example.
+
+[Isomorphic Component Rendering](./isomorphic/)

--- a/examples/type-stripping/src/globals/global.client.ts
+++ b/examples/type-stripping/src/globals/global.client.ts
@@ -1,0 +1,3 @@
+import { toggleTheme } from 'mine.css'
+// @ts-ignore
+window.toggleTheme = toggleTheme

--- a/examples/type-stripping/src/globals/global.css
+++ b/examples/type-stripping/src/globals/global.css
@@ -1,0 +1,3 @@
+@import 'mine.css/dist/mine.css';
+@import 'mine.css/dist/layout.css';
+@import 'highlight.js/styles/github-dark-dimmed.css';

--- a/examples/type-stripping/src/isomorphic/client.ts
+++ b/examples/type-stripping/src/isomorphic/client.ts
@@ -1,0 +1,55 @@
+import { html, Component } from 'htm/preact'
+import { render } from 'preact'
+import { useCallback } from 'preact/hooks'
+import { useSignal, useComputed } from '@preact/signals'
+
+const Header = ({ name }) => html`<h1>${name} List</h1>`
+
+const Footer = props => {
+  const count = useSignal(0)
+  const double = useComputed(() => count.value * 2)
+
+  const handleClick = useCallback(() => {
+    count.value++
+  }, [count])
+
+  return html`<footer ...${props}>
+    ${count}
+    ${double}
+    ${props.children}
+    <button onClick=${handleClick}>Click</button>
+  </footer>`
+}
+
+class App extends Component {
+  addTodo () {
+    const { todos = [] } = this.state
+    this.setState({ todos: todos.concat(`Item ${todos.length}`) })
+  }
+
+  render ({ page }, { todos = [] }) {
+    return html`
+          <div class="app">
+            <${Header} name="ToDo's (${page})" />
+            <ul>
+              ${todos.map(todo => html`
+                <li key=${todo}>${todo}</li>
+              `)}
+            </ul>
+            <button onClick=${() => this.addTodo()}>Add Todo</button>
+            <${Footer}>footer content here<//>
+          </div>
+        `
+  }
+}
+
+export const page = () => html`
+    <${App} page="Isomorphic"/>
+    <${Footer}>footer content here<//>
+    <${Footer}>footer content here<//>
+  `
+
+if (typeof window !== 'undefined') {
+  const renderTarget = document.querySelector('.app-main')
+  render(page(), renderTarget)
+}

--- a/examples/type-stripping/src/isomorphic/page.ts
+++ b/examples/type-stripping/src/isomorphic/page.ts
@@ -1,0 +1,5 @@
+import { page } from './client.ts'
+
+export default () => {
+  return page()
+}

--- a/examples/type-stripping/src/layouts/root.layout.ts
+++ b/examples/type-stripping/src/layouts/root.layout.ts
@@ -1,0 +1,51 @@
+import { html } from 'htm/preact'
+import { render } from 'preact-render-to-string'
+
+import type { LayoutFunction } from 'top-bun'
+
+interface Vars {
+  title?: string
+  siteName?: string
+  defaultStyle?: boolean
+  basePath?: string
+}
+
+type DefaultRootLayout = LayoutFunction<Vars>
+
+const defaultRootLayout: DefaultRootLayout = ({
+  vars: {
+    title,
+    siteName = 'TopBun',
+    basePath,
+  },
+  scripts,
+  styles,
+  children,
+}) => /* html */`
+    <!DOCTYPE html>
+    <html>
+      ${render(html`
+        <head>
+          <meta charset="utf-8" />
+          <title>${title ? `${title}` : ''}${title && siteName ? ' | ' : ''}${siteName}</title>
+          <meta name="viewport" content="width=device-width, user-scalable=no" />
+          ${scripts
+            ? scripts.map(script => html`<script type='module' src="${script.startsWith('/') ? `${basePath ?? ''}${script}` : script}" />`)
+            : null}
+          ${styles
+            ? styles.map(style => html`<link rel="stylesheet" href="${style.startsWith('/') ? `${basePath ?? ''}${style}` : style}" />`)
+            : null}
+        </head>
+      `)}
+      ${render(html`
+        <body class="safe-area-inset">
+          ${typeof children === 'string'
+            ? html`<main class="mine-layout app-main" dangerouslySetInnerHTML="${{ __html: children }}"/>`
+            : html`<main class="mine-layout app-main">${children}</main>`
+          }
+        </body>
+      `)}
+    </html>
+  `
+
+export default defaultRootLayout

--- a/examples/type-stripping/tsconfig.json
+++ b/examples/type-stripping/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "extends": "@voxpelli/tsconfig/node20.json",
+  "compilerOptions": {
+    "skipLibCheck": true,
+    "erasableSyntaxOnly": true,
+    "allowImportingTsExtensions": true,
+    "rewriteRelativeImportExtensions": true,
+    "verbatimModuleSyntax": true
+  },
+  "include": [
+    "**/*",
+  ],
+  "exclude": [
+    "**/*.js",
+    "node_modules",
+    "coverage",
+    ".github"
+  ]
+}

--- a/lib/build-pages/page-data.js
+++ b/lib/build-pages/page-data.js
@@ -26,7 +26,7 @@ export class PageData {
   /** @type {object?} */ builderVars = null
   /** @type {string[]} */ styles = []
   /** @type {string[]} */ scripts = []
-  /** @type {boolean} */ #initalized = false
+  /** @type {boolean} */ #initialized = false
   /** @type {T?} */ #renderedPostVars = null
   /** @type {string?} */ #defaultStyle = null
   /** @type {string?} */ #defaultClient = null
@@ -68,7 +68,7 @@ export class PageData {
    * @return {T} globalVars, pageVars, and buildVars merged together
    */
   get vars () {
-    if (!this.#initalized) throw new Error('Initialize PageData before accessing vars')
+    if (!this.#initialized) throw new Error('Initialize PageData before accessing vars')
     const { globalVars, pageVars, builderVars } = this
     // @ts-ignore
     return {
@@ -82,7 +82,7 @@ export class PageData {
    * @type {import('./resolve-vars.js').PostVarsFunction<T>}
    */
   async #renderPostVars ({ vars, styles, scripts, pages, page }) {
-    if (!this.#initalized) throw new Error('Initialize PageData before accessing renderPostVars')
+    if (!this.#initialized) throw new Error('Initialize PageData before accessing renderPostVars')
     if (!this.postVars) return this.vars
     if (this.#renderedPostVars) return this.#renderedPostVars
 
@@ -106,7 +106,7 @@ export class PageData {
    * @param  {Record<string,ResolvedLayout<T>>} params.layouts - The array of ResolvedLayouts
    */
   async init ({ layouts }) {
-    if (this.#initalized) return
+    if (this.#initialized) return
     const { pageInfo, globalVars } = this
     if (!pageInfo) throw new Error('A page is required to initialize')
     const { pageVars, type } = pageInfo
@@ -156,7 +156,7 @@ export class PageData {
       if (this.#defaultStyle) this.styles.unshift(`/${this.#defaultStyle}`)
     }
 
-    this.#initalized = true
+    this.#initialized = true
   }
 
   /**
@@ -165,7 +165,7 @@ export class PageData {
    * @param  {PageData<T>[]} params.pages An array of initialized PageDatas.
    */
   async renderInnerPage ({ pages }) {
-    if (!this.#initalized) throw new Error('Must be initialized before rendering inner pages')
+    if (!this.#initialized) throw new Error('Must be initialized before rendering inner pages')
     const { pageInfo, styles, scripts, vars } = this
     if (!pageInfo) throw new Error('A page is required to render')
     const builder = pageBuilders[pageInfo.type]
@@ -181,7 +181,7 @@ export class PageData {
    * @param  {PageData<T>[]} params.pages An array of initialized PageDatas.
    */
   async renderFullPage ({ pages }) {
-    if (!this.#initalized) throw new Error('Must be initialized before rendering full pages')
+    if (!this.#initialized) throw new Error('Must be initialized before rendering full pages')
     const { pageInfo, layout, vars, styles, scripts } = this
     if (!pageInfo) throw new Error('A page is required to render')
     if (!layout) throw new Error('A layout is required to render')

--- a/lib/build-static/index.js
+++ b/lib/build-static/index.js
@@ -19,7 +19,8 @@ const copy = cpx.copy
  * @return {string}     - The copy clob
  */
 export function getCopyGlob (src) {
-  return `${src}/**/!(*.js|*.cjs|*.mjs|*.css|*.html|*.md)`
+  // Always ignore files we typically process. Otherwise it gets really confusing.
+  return `${src}/**/!(*.ts|*.mts|*.cts|*.js|*.cjs|*.mjs|*.css|*.html|*.md)`
 }
 
 /**

--- a/lib/helpers/has-ts.js
+++ b/lib/helpers/has-ts.js
@@ -1,0 +1,1 @@
+export const hasTS = [true, 'strip', 'transform'].includes(process?.features?.typescript)

--- a/lib/identify-pages.js
+++ b/lib/identify-pages.js
@@ -3,6 +3,7 @@ import assert from 'node:assert'
 import { resolve, relative, join, basename } from 'path'
 import { pageBuilders } from './build-pages/index.js'
 import { TopBunDuplicatePageError } from './helpers/top-bun-error.js'
+import { hasTS } from './helpers/has-ts.js'
 
 /**
  * @import { FWStats } from 'async-folder-walker'
@@ -11,14 +12,72 @@ import { TopBunDuplicatePageError } from './helpers/top-bun-error.js'
 
 const __dirname = import.meta.dirname
 
-const layoutSuffixs = ['.layout.js', '.layout.mjs', '.layout.cjs']
-const layoutClientSuffixs = ['.layout.client.js', '.layout.client.mjs', '.layout.client.cjs']
-const layoutStyleSuffix = '.layout.css'
-const templateSuffixs = ['.template.js', '.template.mjs', '.template.cjs']
-const globalStyleNames = ['global.css', 'global.style.css']
-const globalClientNames = ['global.client.js', 'global.client.mjs', 'global.client.cjs']
-const globalVarsNames = ['global.vars.js', 'global.vars.mjs', 'global.vars.mjs']
-const esbuildSettingsNames = ['esbuild.settings.js', 'esbuild.settings.cjs', 'esbuild.settings.mjs']
+const getFirstMatch = (/** @type {{ [basename: string]: WalkerFile }} */ files, /** @type {string[][]} */ ...fileNames) => {
+  const flatFileNames = fileNames.flat()
+  for (const filename of flatFileNames) {
+    const firstFound = files[filename]
+    if (firstFound) {
+      return firstFound
+    }
+  }
+}
+
+const jsPageNames = hasTS
+  ? ['page.ts', 'page.mts', 'page.cts', 'page.js', 'page.mjs', 'page.cjs']
+  : ['page.js', 'page.mjs', 'page.cjs']
+
+const jsPageDraftNames = hasTS
+  ? ['page.draft.ts', 'page.draft.mts', 'page.draft.cts', 'page.draft.js', 'page.draft.mjs', 'page.draft.cjs']
+  : ['page.draft.js', 'page.draft.mjs', 'page.draft.cjs']
+
+const pageClientNames = hasTS
+  ? ['client.ts', 'client.mts', 'client.cts', 'client.js', 'client.mjs', 'client.cjs']
+  : ['client.js', 'client.mjs', 'client.cjs']
+
+const pageVarsNames = hasTS
+  ? ['page.vars.ts', 'page.vars.mts', 'page.vars.cts',
+      'page.vars.js', 'page.vars.mjs', 'page.vars.cjs']
+  : ['page.vars.js', 'page.vars.mjs', 'page.vars.cjs']
+
+const layoutSuffixs = hasTS
+  ? ['.layout.ts', '.layout.mts', '.layout.cts', '.layout.js', '.layout.mjs', '.layout.cjs']
+  : ['.layout.js', '.layout.mjs', '.layout.cjs']
+
+const layoutClientSuffixs = hasTS
+  ? [
+      '.layout.client.ts', '.layout.client.mts', '.layout.client.cts',
+      '.layout.client.js', '.layout.client.mjs', '.layout.client.cjs'
+    ]
+  : ['.layout.client.js', '.layout.client.mjs', '.layout.client.cjs']
+
+const layoutStyleSuffix = '.layout.css' // unchanged
+
+const templateSuffixs = hasTS
+  ? ['.template.ts', '.template.mts', '.template.cts', '.template.js', '.template.mjs', '.template.cjs']
+  : ['.template.js', '.template.mjs', '.template.cjs']
+
+const globalStyleNames = ['global.css', 'global.style.css'] // unchanged
+
+const globalClientNames = hasTS
+  ? [
+      'global.client.ts', 'global.client.mts', 'global.client.cts',
+      'global.client.js', 'global.client.mjs', 'global.client.cjs'
+    ]
+  : ['global.client.js', 'global.client.mjs', 'global.client.cjs']
+
+const globalVarsNames = hasTS
+  ? [
+      'global.vars.ts', 'global.vars.mts', 'global.vars.cts',
+      'global.vars.js', 'global.vars.mjs', 'global.vars.cjs'
+    ]
+  : ['global.vars.js', 'global.vars.mjs', 'global.vars.cjs']
+
+const esbuildSettingsNames = hasTS
+  ? [
+      'esbuild.settings.ts', 'esbuild.settings.mts', 'esbuild.settings.cts',
+      'esbuild.settings.js', 'esbuild.settings.mjs', 'esbuild.settings.cjs'
+    ]
+  : ['esbuild.settings.js', 'esbuild.settings.mjs', 'esbuild.settings.cjs']
 
 /**
  * Shape the file walker object
@@ -157,8 +216,8 @@ export async function identifyPages (src, opts = {}) {
   for (const [dir, files] of Object.entries(dirs)) {
     /** @type {PageFile | undefined } */
     const jsPage = opts?.buildDrafts
-      ? files['page.js'] ?? files['page.draft.js']
-      : files['page.js']
+      ? getFirstMatch(files, jsPageNames, jsPageDraftNames)
+      : getFirstMatch(files, jsPageNames)
     if (jsPage) jsPage.type = 'js'
     /** @type {PageFile | undefined} */
     const htmlPage = opts?.buildDrafts
@@ -172,8 +231,8 @@ export async function identifyPages (src, opts = {}) {
     if (readmePage) readmePage.type = 'md'
 
     const pageStyle = files['style.css']
-    const clientBundle = files['client.js']
-    const pageVars = files['page.vars.js']
+    const clientBundle = getFirstMatch(files, pageClientNames)
+    const pageVars = getFirstMatch(files, pageVarsNames)
 
     const conflict = jsPage && htmlPage
 

--- a/lib/identify-pages.test.js
+++ b/lib/identify-pages.test.js
@@ -13,7 +13,7 @@ tap.test('identifyPages works as expected', async (t) => {
   t.ok(results.layouts, 'Layouts are found')
 
   t.ok(results.layouts['root'], 'A root layouts is found')
-  t.equal(Object.keys(results.pages).length, 22, '22 pages are found')
+  t.equal(Object.keys(results.pages).length, 23, '23 pages are found')
 
   t.equal(results.warnings.length, 0, '0 warnings produced')
   // t.equal(results.nonPageFolders.length, 4, '4 non-page-folder')

--- a/test-cases/general-features/src/blog/2025/a-blog-post-from-2025/page.ts
+++ b/test-cases/general-features/src/blog/2025/a-blog-post-from-2025/page.ts
@@ -1,0 +1,9 @@
+export default function ()  {
+  return `Hello world, from 2025. Also typescript`
+}
+
+export const vars = {
+  layout: 'ts',
+  publishDate: "2023-03-01T18:06:24.000Z",
+  title: "A Blogpost from 2025"
+} as const

--- a/test-cases/general-features/src/layouts/ts.layout.ts
+++ b/test-cases/general-features/src/layouts/ts.layout.ts
@@ -1,0 +1,69 @@
+import defaultRootLayout from './root.layout.js';
+// @ts-ignore
+import { html } from 'uhtml-isomorphic';
+import type { LayoutFunction } from '../../../../index.js';
+
+// Import SiteVars type from root layout
+import type { SiteVars } from './root.layout.js';
+
+type tsLayout = LayoutFunction<SiteVars>
+
+export default function tsLayout(layoutVars: LayoutFunction<SiteVars>): string | HTMLElement {
+  // @ts-ignore
+  const { children: innerChildren, ...rest } = layoutVars;
+  // @ts-ignore
+  const vars = layoutVars.vars;
+
+  const children = html`
+    <article class="article-layout h-entry" itemscope itemtype="http://schema.org/NewsArticle">
+      <header class="article-header">
+        <h1 class="p-name article-title" itemprop="headline">${vars.title}</h1>
+        <div class="metadata">
+          <address class="author-info" itemprop="author" itemscope itemtype="http://schema.org/Person">
+            ${vars.authorImgUrl
+              ? html`<img height="40" width="40"  src="${vars.authorImgUrl}" alt="${vars.authorImgAlt}" class="u-photo" itemprop="image">`
+              : null
+            }
+            ${vars.authorName && vars.authorUrl
+              ? html`
+                  <a href="${vars.authorUrl}" class="p-author h-card" itemprop="url">
+                    <span itemprop="name">${vars.authorName}</span>
+                  </a>`
+              : null
+            }
+          </address>
+          ${vars.publishDate
+            ? html`
+              <time class="dt-published" itemprop="datePublished" datetime="${vars.publishDate}">
+                <a href="#" class="u-url">
+                  ${(new Date(vars.publishDate)).toLocaleString()}
+                </a>
+              </time>`
+            : null
+          }
+          ${vars.updatedDate
+            ? html`<time class="dt-updated" itemprop="dateModified" datetime="${vars.updatedDate}">Updated ${(new Date(vars.updatedDate)).toLocaleString()}</time>`
+            : null
+          }
+        </div>
+      </header>
+
+      <section class="e-content" itemprop="articleBody">
+        ${typeof innerChildren === 'string'
+          ? html([innerChildren])
+          : innerChildren /* Support both uhtml and string children. Optional. */
+        }
+      </section>
+
+      <!--
+        <footer>
+            <p>Footer notes or related info here...</p>
+        </footer>
+      -->
+    </article>
+  `;
+
+  const rootArgs = { ...rest, children };
+  // @ts-ignore
+  return defaultRootLayout(rootArgs);
+}


### PR DESCRIPTION
This enables support for .ts files anywhere in top-bun you could use a .js file. In node contexts, type stripping is provided by node itself, so be sure to enable that feature in Node.js In client contexts, esbuild strips the types.